### PR TITLE
404 handling

### DIFF
--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -1,6 +1,6 @@
 React = require 'react/addons'
 Router = require 'react-router'
-{Route, RouteHandler, DefaultRoute, Link} = require 'react-router'
+{Route, RouteHandler, DefaultRoute, NotFoundRoute, Link} = require 'react-router'
 Reflux = require 'reflux'
 projectConfig = require './lib/config'
 {api} = client = require './api/client'
@@ -36,10 +36,12 @@ routes =
     <Route name="field-guide" path="field-guide" handler={require './pages/field-guide'}>
       <Route name="field-guide-entry" path=":entryName" handler={require './partials/field-guide-entry'} />
     </Route>
+
+    <NotFoundRoute handler={require './pages/not-found'} />
   </Route>
 
-Router.run routes, (Handler) ->
-  React.render <Handler />, document.getElementById("app")
+Router.run routes, (Root) ->
+  React.render <Root />, document.getElementById("app")
 
 window.React = React
 window.api = api

--- a/app/pages/not-found.cjsx
+++ b/app/pages/not-found.cjsx
@@ -1,0 +1,21 @@
+React = require 'react'
+counterpart = require 'counterpart'
+Translate = require 'react-translate-component'
+
+counterpart.registerTranslations 'en',
+  notFoundPage:
+    header: 'Page Not Found'
+    text: 'Sorry, the page you were looking for was not found. Try one of the links above.'
+
+module.exports = React.createClass
+  statics:
+    willTransitionTo: (transition, query, params) ->
+      if transition.path.charAt(transition.path.length - 1) == '/'
+        newPath = transition.path.slice 0, transition.path.length - 1
+        transition.redirect newPath, query, params
+
+  render: ->
+    <div className="secondary-page">
+      <Translate component="h1" content="notFoundPage.header" />
+      <Translate component="p" content="notFoundPage.text" />
+    </div>

--- a/css/secondary-page.styl
+++ b/css/secondary-page.styl
@@ -2,6 +2,7 @@
   color: white
   margin: 0 auto
   max-width: 700px
+  min-height: 100vh
   padding: 100px 3vw
 
   a


### PR DESCRIPTION
- Handles trailing slashes in the URL.
- I'm not 100% sure on https://github.com/zooniverse/wildcam-gorongosa/blob/da6f2133bad9340cac764cd60cf9343ce1a7ab57/app/pages/not-found.cjsx#L13. Feels like a recipe for some edge case I can't think of. A regex might be more thorough here. This version does work as far as I can test.
