### PR TITLE
Fix annotation object being pushed to store. Switch to survey summary

### DIFF
--- a/app/pages/classify.cjsx
+++ b/app/pages/classify.cjsx
@@ -11,10 +11,11 @@ classificationStore = require '../stores/classification-store'
 subjectStore = require '../stores/subject-store'
 workflowStore = require '../stores/workflow-store'
 
+annotationActions = require '../actions/annotation-actions'
 classifierActions = require '../actions/classifier-actions'
 
 Task = require '../tasks/survey'
-Summary = require '../partials/summary'
+Summary = require '../tasks/survey/summary'
 
 module.exports = React.createClass
   displayName: "Classify"
@@ -44,6 +45,10 @@ module.exports = React.createClass
     #   @toggleTutorial()
     # else if nextProps.user is null
     #   @toggleTutorial()
+
+  componentWillUpdate: (nextProps, nextState) ->
+    if nextState.subject isnt @state.subject
+      annotationActions.clear()
 
   toggleTutorial: ->
     @setState tutorialIsOpen: !@state.tutorialIsOpen
@@ -83,7 +88,7 @@ module.exports = React.createClass
           {if @state.subject && @state.classification && @state.annotations && @state.workflow
             if @state.onSummary
               <div>
-                <Summary annotations={@state.annotations} />
+                <Summary annotations={@state.annotations} task={@state.workflow.tasks['T1']} expanded={true} />
                 <div className="workflow-buttons-container">
                   <button type="button" className="action-button" onClick={@onClickNextImage}>Next Image</button>
                 </div>

--- a/app/tasks/survey/index.cjsx
+++ b/app/tasks/survey/index.cjsx
@@ -63,8 +63,9 @@ module.exports = React.createClass
   handleAnnotation: (choice, answers, e) ->
     filters = JSON.parse JSON.stringify @state.filters
 
-    @props.annotation.value ?= []
-    @props.annotation.value.push {choice, answers, filters}
+    @props.annotation.push {task: @props.task.type, value: []}
+    @props.annotation[0].value ?= []
+    @props.annotation[0].value.push {choice, answers, filters}
     @props.onChange e
 
     @clearFilters()

--- a/app/tasks/survey/summary.cjsx
+++ b/app/tasks/survey/summary.cjsx
@@ -22,10 +22,10 @@ module.exports = React.createClass
       </div>
       <div className="answers">
         <div className="answer">
-          {@props.annotation.value.length} identifications
+          {@props.annotations[0].value.length} identifications
         </div>
         {if @state.expanded
-          choiceSummaries = for identification in @props.annotation.value
+          choiceSummaries = for identification in @props.annotations[0].value
             choice = @props.task.choices[identification.choice]
             allAnswers = for questionID in @props.task.questionsOrder when questionID of identification.answers
               answerLabels = for answerID in [].concat identification.answers[questionID]


### PR DESCRIPTION
- Changed how 'handleAnnotation' stores the annotation so it is the object that the api is expecting
- Clear annotations when a new subject is loaded
- Switch to use existing survey summary component.
