### PR TITLE
Break Field guide pages into components

### DIFF
--- a/app/lib/field-guide-content/aardvark.coffee
+++ b/app/lib/field-guide-content/aardvark.coffee
@@ -1,0 +1,77 @@
+module.exports =
+  mainImage: 'http://placehold.it/400'
+  content: -> '''
+
+    <h1 id="scientific-name"><em>(Orycteropus afer)</em></h1>
+
+    <div id="top">
+      <div class="columns">
+        <div class="column">
+          <img src="https://static1.squarespace.com/static/55cde660e4b0ad0fe7822a58/t/55ce2d4ee4b07630b3dd1d43/1439575375599/?format=1500w"/>
+
+          <p id="intro">Aardvarks are the last survivors of a group of primitive ungulates. They have a stocky body with thick skin that ranges in color from yellowish to pinkish and is sparsely covered with bristly hair. Aardvarks have short, powerful legs with sharp claws (four on the forefeet and five on each hind foot), a prominently arched back, a short neck, long pointed ears, and a long muscular tail that tapers to a point. Their head is elongated with a long snout. They are well adapted to feed on termites and ants with nostrils that can be sealed and a protractile tongue. </p>
+        </div>
+
+        <div class = "column">
+          <h2 id="status">Conservation Status</h2>
+          <p>Least Concern</p>
+          <img src="https://static1.squarespace.com/static/55cde660e4b0ad0fe7822a58/t/55ce2beae4b06614877ad3b2/1439571968414/?format=300w"/>
+        </div>
+
+      </div>
+    </div>
+
+
+
+
+    <div class="columns">
+
+      <div class="column">
+
+        <h2>Habitat</h2>
+        <p>Aardvarks live in a wide range of habitats, from dry savannas to rain forests. Aardvarks are absent from hyperarid habitats and generally avoid extremely rocky terrain, which makes it difficult for them to dig for their main food source (termites and ants). </p>
+
+        <h2>Diet</h2>
+        <p>Aardvarks are specialized eaters, feeding almost exclusively on termites and ants.</p>
+
+        <h2>Predators</h2>
+        <p>Humans, lions, leopards, hyenas, pythons</p>
+
+        <div class="fun-box">
+          <h3>Fun Facts</h3>
+          <ol>
+             <li>An aardvark’s tongue can reach lengths of 30.5 cm—that’s as big as a school ruler!</li>
+             <li>The name “aardvark” comes from South Africa’s national language, Afrikaans, and means “earth pig.”</li>
+             <li>Aardvarks are cited as being able to dig up to 62 cm or 2 feet in 15 seconds!</li>
+             <li>The aardvark is the only living representative of an entire order of animals, the Tubulidentata.</li>
+             <li>Aardvarks can eat up to 50,000 insects each night!</li>
+          </ol>
+        </div>
+      </div>
+
+      <div class="column">
+
+
+        <h2>Behavior</h2>
+        <p>Aardvarks are primarily solitary nocturnal animals, spending most of the day asleep in their burrow. At night aardvarks leave their burrow in search of food, traveling in a zigzag pattern and using their elongated snout to help them locate prey. Once they find a termite mound, aardvarks use their well-adapted claws to dig into the earth and their long, sticky, protractile tongue to easily gather prey. An individual aardvark can eat over 50,000 individual termites in a single night! </p>
+
+
+        <h2>Breeding</h2>
+        <p>Aardvarks are solitary, coming together only to breed. Female aardvarks give birth to a single hairless young after a gestation period of about seven months. Young aardvarks stay with their mothers until they are reared. They will not leave the mother’s burrow during the first two weeks of life. After three months of nursing, they begin to eat insects. By six months, the young can dig and forage for themselves, and by 12 months they will have reached the size of a mature adult. Sexual maturity is reached at about two years of age.</p>
+
+        <div class="deets-box">
+          <h2>Size</h2>
+          <p>Length: 1.03-1.3 m</p>
+          <p>Height: 60-65 cm</p>
+
+          <h2>Weight</h2>
+          <p>40-65 kg </p>
+
+          <p><span>Lifespan:</span>23 years in captivity</p>
+          <p><span>Gestation:</span>7 months</p>
+          <p><span>Average number of offspring:</span>1</p>
+
+        </div>
+      </div>
+    </div>
+  '''

--- a/app/lib/field-guide-content/aardvark.coffee
+++ b/app/lib/field-guide-content/aardvark.coffee
@@ -8,14 +8,13 @@ module.exports =
       <div class="columns">
         <div class="column">
           <img src="https://static1.squarespace.com/static/55cde660e4b0ad0fe7822a58/t/55ce2d4ee4b07630b3dd1d43/1439575375599/?format=1500w"/>
-
-          <p id="intro">Aardvarks are the last survivors of a group of primitive ungulates. They have a stocky body with thick skin that ranges in color from yellowish to pinkish and is sparsely covered with bristly hair. Aardvarks have short, powerful legs with sharp claws (four on the forefeet and five on each hind foot), a prominently arched back, a short neck, long pointed ears, and a long muscular tail that tapers to a point. Their head is elongated with a long snout. They are well adapted to feed on termites and ants with nostrils that can be sealed and a protractile tongue. </p>
         </div>
 
         <div class = "column">
           <h2 id="status">Conservation Status</h2>
           <p>Least Concern</p>
           <img src="https://static1.squarespace.com/static/55cde660e4b0ad0fe7822a58/t/55ce2beae4b06614877ad3b2/1439571968414/?format=300w"/>
+          <p id="intro">Aardvarks are the last survivors of a group of primitive ungulates. They have a stocky body with thick skin that ranges in color from yellowish to pinkish and is sparsely covered with bristly hair. Aardvarks have short, powerful legs with sharp claws (four on the forefeet and five on each hind foot), a prominently arched back, a short neck, long pointed ears, and a long muscular tail that tapers to a point. Their head is elongated with a long snout. They are well adapted to feed on termites and ants with nostrils that can be sealed and a protractile tongue. </p>
         </div>
 
       </div>
@@ -25,7 +24,6 @@ module.exports =
 
 
     <div class="columns">
-
       <div class="column">
 
         <h2>Habitat</h2>
@@ -37,6 +35,21 @@ module.exports =
         <h2>Predators</h2>
         <p>Humans, lions, leopards, hyenas, pythons</p>
 
+      </div>
+
+      <div class="column">
+
+        <h2>Behavior</h2>
+        <p>Aardvarks are primarily solitary nocturnal animals, spending most of the day asleep in their burrow. At night aardvarks leave their burrow in search of food, traveling in a zigzag pattern and using their elongated snout to help them locate prey. Once they find a termite mound, aardvarks use their well-adapted claws to dig into the earth and their long, sticky, protractile tongue to easily gather prey. An individual aardvark can eat over 50,000 individual termites in a single night! </p>
+
+
+        <h2>Breeding</h2>
+        <p>Aardvarks are solitary, coming together only to breed. Female aardvarks give birth to a single hairless young after a gestation period of about seven months. Young aardvarks stay with their mothers until they are reared. They will not leave the mother’s burrow during the first two weeks of life. After three months of nursing, they begin to eat insects. By six months, the young can dig and forage for themselves, and by 12 months they will have reached the size of a mature adult. Sexual maturity is reached at about two years of age.</p>
+
+      </div>
+    </div>
+
+    <div class="boxes">
         <div class="fun-box">
           <h3>Fun Facts</h3>
           <ol>
@@ -47,17 +60,6 @@ module.exports =
              <li>Aardvarks can eat up to 50,000 insects each night!</li>
           </ol>
         </div>
-      </div>
-
-      <div class="column">
-
-
-        <h2>Behavior</h2>
-        <p>Aardvarks are primarily solitary nocturnal animals, spending most of the day asleep in their burrow. At night aardvarks leave their burrow in search of food, traveling in a zigzag pattern and using their elongated snout to help them locate prey. Once they find a termite mound, aardvarks use their well-adapted claws to dig into the earth and their long, sticky, protractile tongue to easily gather prey. An individual aardvark can eat over 50,000 individual termites in a single night! </p>
-
-
-        <h2>Breeding</h2>
-        <p>Aardvarks are solitary, coming together only to breed. Female aardvarks give birth to a single hairless young after a gestation period of about seven months. Young aardvarks stay with their mothers until they are reared. They will not leave the mother’s burrow during the first two weeks of life. After three months of nursing, they begin to eat insects. By six months, the young can dig and forage for themselves, and by 12 months they will have reached the size of a mature adult. Sexual maturity is reached at about two years of age.</p>
 
         <div class="deets-box">
           <h2>Size</h2>
@@ -70,8 +72,6 @@ module.exports =
           <p><span>Lifespan:</span>23 years in captivity</p>
           <p><span>Gestation:</span>7 months</p>
           <p><span>Average number of offspring:</span>1</p>
-
         </div>
-      </div>
     </div>
   '''

--- a/app/lib/field-guide-content/aardvark.coffee
+++ b/app/lib/field-guide-content/aardvark.coffee
@@ -14,7 +14,7 @@ module.exports =
           <h2 id="status">Conservation Status</h2>
           <p>Least Concern</p>
           <img src="https://static1.squarespace.com/static/55cde660e4b0ad0fe7822a58/t/55ce2beae4b06614877ad3b2/1439571968414/?format=300w"/>
-          <p id="intro">Aardvarks are the last survivors of a group of primitive ungulates. They have a stocky body with thick skin that ranges in color from yellowish to pinkish and is sparsely covered with bristly hair. Aardvarks have short, powerful legs with sharp claws (four on the forefeet and five on each hind foot), a prominently arched back, a short neck, long pointed ears, and a long muscular tail that tapers to a point. Their head is elongated with a long snout. They are well adapted to feed on termites and ants with nostrils that can be sealed and a protractile tongue. </p>
+          <p id="intro"><span>Aardvarks</span> are the last survivors of a group of primitive ungulates. They have a stocky body with thick skin that ranges in color from yellowish to pinkish and is sparsely covered with bristly hair. Aardvarks have short, powerful legs with sharp claws (four on the forefeet and five on each hind foot), a prominently arched back, a short neck, long pointed ears, and a long muscular tail that tapers to a point. Their head is elongated with a long snout. They are well adapted to feed on termites and ants with nostrils that can be sealed and a protractile tongue. </p>
         </div>
 
       </div>

--- a/app/lib/field-guide-content/baboon.coffee
+++ b/app/lib/field-guide-content/baboon.coffee
@@ -8,24 +8,19 @@ module.exports =
       <div class="columns">
         <div class="column">
           <img src="https://static1.squarespace.com/static/55cde660e4b0ad0fe7822a58/t/55ce2d4ee4b07630b3dd1d43/1439575375599/?format=1500w"/>
-
-          <p id="intro">Yellow baboons are aptly named for the yellow-brown fur that covers most of their bodies. The underside of yellow baboons is white, and their face, ears, hands, feet, and posterior appear purplish-black in color and are free of fur. Like other baboons, yellow baboons have doglike noses, powerful jaws, and sharp canine teeth, and they lack a prehensile (gripping) tail. Yellow baboons are the largest baboon and are highly sexually dimorphic.</p>
         </div>
 
         <div class = "column">
           <h2 id="status">Conservation Status</h2>
           <p>Least Concern</p>
           <img src="https://static1.squarespace.com/static/55cde660e4b0ad0fe7822a58/t/55ce2beae4b06614877ad3b2/1439571968414/?format=300w"/>
+          <p id="intro">Yellow baboons are aptly named for the yellow-brown fur that covers most of their bodies. The underside of yellow baboons is white, and their face, ears, hands, feet, and posterior appear purplish-black in color and are free of fur. Like other baboons, yellow baboons have doglike noses, powerful jaws, and sharp canine teeth, and they lack a prehensile (gripping) tail. Yellow baboons are the largest baboon and are highly sexually dimorphic.</p>
         </div>
-
-      </div>
-    </div>
-
-
+      </div> <!--closes columns-->
+    </div> <!--closes top-->
 
 
     <div class="columns">
-
       <div class="column">
 
         <h2>Habitat</h2>
@@ -37,40 +32,40 @@ module.exports =
         <h2>Predators</h2>
         <p>Humans, leopards, cheetah</p>
 
-        <div class="fun-box">
-          <h3>Fun Facts</h3>
-          <ol>
-            <li>The scientific name for yellow baboons comes from the Greek words kynos and kephalikos, meaning “dog” and “head.”</li>
-            <li>Yellow baboons are the largest species of baboon</li>
-          </ol>
-        </div>
       </div>
 
       <div class="column">
-
-
         <h2>Behavior</h2>
-        <p>Yellow baboons are highly social, living in groups known as troops, which can contain dozens or even hundreds of individuals of both sexes. Baboons sleep, feed, travel, and socialize within troops. Male baboons compete for dominance, with high-ranking males having an advantage when it comes to mating, food, water, and territory. Troops spend the majority of the day on the ground foraging for a wide variety of foods with intermittent periods of socialization. Baboons groom one another to remove insects and dead skin and use barklike vocalizations. Yellow baboons also exhibit other behaviors such as branch-shaking, teeth displays, ground-slapping, and yawning as forms of communication.</p>
+        <p>Yellow baboons are highly social, living in groups known as troops, which can contain dozens or even hundreds of individuals of both sexes. Baboons sleep, feed, travel, and socialize within troops. Male baboons compete for    dominance, with high-ranking males having an advantage when it comes to mating, food, water, and territory. Troops spend the majority of the day on the ground foraging for a wide variety of foods with intermittent periods of socialization. Baboons groom one another to remove insects and dead skin and use barklike vocalizations. Yellow baboons also exhibit other behaviors such as branch-shaking, teeth displays, ground-slapping, and yawning as forms of communication.</p>
 
         <p>Yellow baboons move on all fours over the ground with their tail raised in the air at an angle. Like other Old World Monkeys, they lack a prehensile (gripping) tail but are still able to climb trees with ease to eat, sleep, and play.<p>
 
         <h2>Breeding</h2>
         <p>Mating is polygynandrous, with both males and females mating with multiple partners. Females reach sexual maturity at around five years of age. After a gestation period of about six months, yellow baboons typically give birth to one young. Weaning occurs sometime around one year of age. Females generally reproduce every two years and will continue to reproduce consistently until old age. Most parental behavior is performed by the female; females nurse, groom, and play with their offspring.</p>
+      </div>
+    </div>
 
-        <div class="deets-box">
-          <h2>Size</h2>
-          <p>Length: 50-79 cm</p>
-          <p>Tail Length: 35-75 cm</p>
+    <div class="boxes"> <!--still need to split boxes into columns?-->
+      <div class="fun-box">
+        <h3>Fun Facts</h3>
+        <ol>
+          <li>The scientific name for yellow baboons comes from the Greek words kynos and kephalikos, meaning “dog” and “head.”</li>
+          <li>Yellow baboons are the largest species of baboon</li>
+        </ol>
+      </div>
 
-          <h2>Weight</h2>
-          <p>Male: 21-26 kg</p>
-          <p>Female: 12-14 kg</p>
+      <div class="deets-box">
+        <h2>Size</h2>
+        <p>Length: 50-79 cm</p>
+        <p>Tail Length: 35-75 cm</p>
 
-          <p><span>Lifespan:</span>20-30 years</p>
-          <p><span>Gestation:</span>6 months</p>
-          <p><span>Average number of offspring:</span>1</p>
+        <h2>Weight</h2>
+        <p>Male: 21-26 kg</p>
+        <p>Female: 12-14 kg</p>
 
-        </div>
+        <p><span>Lifespan:</span>20-30 years</p>
+        <p><span>Gestation:</span>6 months</p>
+        <p><span>Average number of offspring:</span>1</p>
       </div>
     </div>
   '''

--- a/app/lib/field-guide-content/baboon.coffee
+++ b/app/lib/field-guide-content/baboon.coffee
@@ -1,10 +1,32 @@
 module.exports =
   mainImage: 'http://placehold.it/400'
   content: -> '''
+
+    <h1 id="scientific-name"><em>(Papio cynocephalus)</em></h1>
+
+    <div id="top">
+      <div class="columns">
+        <div class="column">
+          <img src="https://static1.squarespace.com/static/55cde660e4b0ad0fe7822a58/t/55ce2d4ee4b07630b3dd1d43/1439575375599/?format=1500w"/>
+
+          <p id="intro">Yellow baboons are aptly named for the yellow-brown fur that covers most of their bodies. The underside of yellow baboons is white, and their face, ears, hands, feet, and posterior appear purplish-black in color and are free of fur. Like other baboons, yellow baboons have doglike noses, powerful jaws, and sharp canine teeth, and they lack a prehensile (gripping) tail. Yellow baboons are the largest baboon and are highly sexually dimorphic.</p>
+        </div>
+
+        <div class = "column">
+          <h2 id="status">Conservation Status</h2>
+          <p>Least Concern</p>
+          <img src="https://static1.squarespace.com/static/55cde660e4b0ad0fe7822a58/t/55ce2beae4b06614877ad3b2/1439571968414/?format=300w"/>
+        </div>
+
+      </div>
+    </div>
+
+
+
+
     <div class="columns">
+
       <div class="column">
-        <h1>Papio cynocephalus</h1>
-        <p>Yellow baboons are aptly named for the yellow-brown fur that covers most of their bodies. The underside of yellow baboons is white, and their face, ears, hands, feet, and posterior appear purplish-black in color and are free of fur. Like other baboons, yellow baboons have doglike noses, powerful jaws, and sharp canine teeth, and they lack a prehensile (gripping) tail. Yellow baboons are the largest baboon and are highly sexually dimorphic.</p>
 
         <h2>Habitat</h2>
         <p>Yellow baboons are found in savanna grassland, steppe, and rainforest habitats.</p>
@@ -12,8 +34,10 @@ module.exports =
         <h2>Diet</h2>
         <p>Grasses, seeds, lichens, fruits, flowers, invertebrates, reptiles, birds, and other primates, such as vervet monkeys and bushbabies</p>
 
+        <h2>Predators</h2>
+        <p>Humans, leopards, cheetah</p>
 
-        <div class="box">
+        <div class="fun-box">
           <h3>Fun Facts</h3>
           <ol>
             <li>The scientific name for yellow baboons comes from the Greek words kynos and kephalikos, meaning “dog” and “head.”</li>
@@ -23,11 +47,7 @@ module.exports =
       </div>
 
       <div class="column">
-        <h2>Conservation Status</h2>
-        <p>Least Concern</p>
-        
-        <h2>Predators</h2>
-        <p>Humans, leopards, cheetah</p>
+
 
         <h2>Behavior</h2>
         <p>Yellow baboons are highly social, living in groups known as troops, which can contain dozens or even hundreds of individuals of both sexes. Baboons sleep, feed, travel, and socialize within troops. Male baboons compete for dominance, with high-ranking males having an advantage when it comes to mating, food, water, and territory. Troops spend the majority of the day on the ground foraging for a wide variety of foods with intermittent periods of socialization. Baboons groom one another to remove insects and dead skin and use barklike vocalizations. Yellow baboons also exhibit other behaviors such as branch-shaking, teeth displays, ground-slapping, and yawning as forms of communication.</p>
@@ -36,6 +56,21 @@ module.exports =
 
         <h2>Breeding</h2>
         <p>Mating is polygynandrous, with both males and females mating with multiple partners. Females reach sexual maturity at around five years of age. After a gestation period of about six months, yellow baboons typically give birth to one young. Weaning occurs sometime around one year of age. Females generally reproduce every two years and will continue to reproduce consistently until old age. Most parental behavior is performed by the female; females nurse, groom, and play with their offspring.</p>
+
+        <div class="deets-box">
+          <h2>Size</h2>
+          <p>Length: 50-79 cm</p>
+          <p>Tail Length: 35-75 cm</p>
+
+          <h2>Weight</h2>
+          <p>Male: 21-26 kg</p>
+          <p>Female: 12-14 kg</p>
+
+          <p><span>Lifespan:</span>20-30 years</p>
+          <p><span>Gestation:</span>6 months</p>
+          <p><span>Average number of offspring:</span>1</p>
+
+        </div>
       </div>
     </div>
   '''

--- a/css/field-guide.styl
+++ b/css/field-guide.styl
@@ -20,9 +20,16 @@
         flex: 0 0 48%
         margin: 1em 0
 
-    .box
+    .fun-box
       background: #654
       padding: 1em
-      
+
+    .deets-box
+      background: #654
+      padding: 1em
+
+    .deets-box span
+      font-size: 20px
+
 .entry-link
   margin: 0 0.5em

--- a/css/field-guide.styl
+++ b/css/field-guide.styl
@@ -21,11 +21,13 @@
         margin: 1em 0
 
     .fun-box
+      width:50%
       background: #654
       padding: 1em
 
     .deets-box
-      background: #654
+      width: 50%
+      background: #652
       padding: 1em
 
     .deets-box span


### PR DESCRIPTION
I tried to create the html tags to reflect the different components for each page, though I've just sort of made up this structure:

At the top, we want:
- species common name (that you're pulling in from somewheres)
- scientific name
- IUCN status (plus IUCN icon)
- Main image (typically named sppname-feature.png)
- Introduction/blurb

A body of info (typically with the following info plopped in):
- Habitat
- Diet
- Predators
- Behavior
- Breeding

A couple of boxes (that I think should be pinned to the bottom, but currently aren't really structured or anything)
- Fun Facts box (this varies in length - seems to be a list of 1 or 2 line factoids)
- Details, with three subsections: 
  - Size
  - Weight
  - Lifespan, Gestation Period, Avg Number of Offspring

What I don't know is how flexibly we can divide content in each section across columns for the body section.
