### PR TITLE
Directly call classification store finish rather than through listener

### DIFF
--- a/app/stores/classification-store.coffee
+++ b/app/stores/classification-store.coffee
@@ -14,7 +14,6 @@ module.exports = Reflux.createStore
   data: null
 
   init: ->
-    @listenTo classifierActions.finishClassification, @finish
     @listenTo workflowStore, @onReceiveData
     @listenTo subjectStore, @onReceiveData
 
@@ -53,6 +52,7 @@ module.exports = Reflux.createStore
     @data.update upsert
       .save()
       .then (classification) ->
+        console.log 'classification saved', classification
         classification.destroy()
       .catch (error) ->
         console.error 'error saving c', error

--- a/app/stores/classifier-store.coffee
+++ b/app/stores/classifier-store.coffee
@@ -1,5 +1,7 @@
 Reflux = require 'reflux'
 
+classificationStore = require '../stores/classification-store'
+
 module.exports = Reflux.createStore
   listenables: [
     require '../actions/classifier-actions'
@@ -30,6 +32,7 @@ module.exports = Reflux.createStore
     @trigger @data
 
   onFinishClassification: ->
+    classificationStore.finish()
     @data.showingSummary = true
     @trigger @data
 


### PR DESCRIPTION
- Fixed #45 

I couldn't get the action listener to work with calling the classification store's finish method. I'm not sure if it's a matter of misunderstanding action listeners in Reflux or if something is buggy. I came across this a few times with working with it in mammoths. Anyway, `classificationStore.finish()` is now being called directly in `onFinishClassification` in the classifier-store
