### PR TITLE
Listen to moveToNextSubject in favorites store

### DIFF
--- a/app/components/favorites-button.cjsx
+++ b/app/components/favorites-button.cjsx
@@ -6,15 +6,10 @@ favoritesStore = require '../stores/favorites-store'
 
 module.exports = React.createClass
   displayName: 'FavoritesButton'
-  mixins: [Reflux.connect(favoritesStore, 'favorites')]
-
-  getInitialState: ->
-    favorited: favoritesStore.favorited
+  mixins: [Reflux.connect(favoritesStore, 'favorited')]
 
   onClick: ->
-    @setState({favorited: !@state.favorited}, ->
-      favoritesStore.toggleFavorite()
-    )
+    favoritesStore.toggleFavorite()
 
   render: ->
     disabledCondition = !@props.user?

--- a/app/partials/summary.cjsx
+++ b/app/partials/summary.cjsx
@@ -13,7 +13,7 @@ module.exports = React.createClass
       <div className="task-summary-annotations">
         <h3 className="task-summary-header">Your Classification Summary</h3>
         <ul className="task-summary-annotations-list">
-          {for annotation in @props.annotations
+          {for annotation, i in @props.annotations
             species = task.choices[annotation.choice].label
             plural = 
               if annotation.answers["HWMN"] > 1
@@ -29,7 +29,7 @@ module.exports = React.createClass
                     "#{species}s"
               else
                 species
-            <li className="task-summary-annotations-list-item">
+            <li key={i} className="task-summary-annotations-list-item">
               <span className="item-species">{plural}</span><span className="item-number">{annotation.answers["HWMN"]}</span>
             </li>
         }</ul>

--- a/app/stores/favorites-store.coffee
+++ b/app/stores/favorites-store.coffee
@@ -1,11 +1,13 @@
 Reflux = require 'reflux'
 projectConfig = require '../lib/config'
 subjectStore = require '../stores/subject-store'
+classifierActions = require '../actions/classifier-actions'
 {api} = require '../api/client'
 
 module.exports = Reflux.createStore
   init: ->
     @listenTo subjectStore, @getFavorites
+    @listenTo classifierActions.moveToNextSubject, @getSubjectInCollection
 
   getInitialState: ->
     @favorited
@@ -24,8 +26,9 @@ module.exports = Reflux.createStore
     @subjectID = subjectStore.data.id
     if favorites?
       favorites.get('subjects', id: @subjectID)
-        .then ([subject]) ->
+        .then ([subject]) =>
           @favorited = subject?
+          @trigger @favorited
 
   createFavorites: ->
     project = projectConfig.projectId


### PR DESCRIPTION
- Fixed #146 by listening to `classifierActions.moveToNextSubject` in the favorites store.
- Fixed React warning in summary component too.
