### PR TITLE
Use latest polyfill service for MS Edge support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,7 @@
   <body>
     <div id="app"></div>
   </body>
-  <script src="https://cdn.polyfill.io/v1/polyfill.min.js?features=default,es6,Promise,fetch,Object.assign&amp;flags=gated"></script>
+  <script src="http://qa.polyfill.io/v1/polyfill.js?unknown=polyfill&amp;features=default,es6,Promise,fetch,Object.assign&amp;flags=gated"></script>
   <script src="./app.js"></script>
   <script>
    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
Win 10/MS Edge vm is now available on modern.ie for testing and found that the fetch polyfill wasn't working. This updates the polyfill service to use [the latest](https://github.com/Financial-Times/polyfill-service/issues/460) on qa.polyfill.io with the unknown query string to get fetch to work in Edge.
