### PR TITLE
cache the set of subjects for classification

### DIFF
--- a/app/stores/classification-store.coffee
+++ b/app/stores/classification-store.coffee
@@ -18,7 +18,7 @@ module.exports = Reflux.createStore
     @listenTo subjectStore, @onReceiveData
 
   onReceiveData: ->
-    if workflowStore.data and subjectStore.data
+    if workflowStore.data and subjectStore.subject
       @create()
 
   create: ->
@@ -32,7 +32,7 @@ module.exports = Reflux.createStore
       links:
         project: config.projectId
         workflow: config.workflowId
-        subjects: [subjectStore.data.id]
+        subjects: [subjectStore.subject.id]
 
     @trigger @data
 

--- a/app/stores/favorites-store.coffee
+++ b/app/stores/favorites-store.coffee
@@ -23,7 +23,7 @@ module.exports = Reflux.createStore
         @getSubjectInCollection(@favorites)
 
   getSubjectInCollection: (favorites) ->
-    @subjectID = subjectStore.data.id
+    @subjectID = subjectStore.subject.id
     if favorites?
       favorites.get('subjects', id: @subjectID)
         .then ([subject]) =>


### PR DESCRIPTION
don't call the selection end point for each subject, call it on load, store the results and then iterate through them till empty, then refresh the local store and repeat. This was depleting the api subject queues 10X (default page size) faster than normal and triggering a lot of concurrent reubilds that stressed the DB and api nodes.
