### PR TITLE
non logged in will be null user

### DIFF
--- a/app/stores/favorites-store.coffee
+++ b/app/stores/favorites-store.coffee
@@ -18,7 +18,7 @@ module.exports = Reflux.createStore
     query =
       project_id: projectConfig.projectId
       favorite: true
-      owner: userStore.userData.user.login
+      owner: userStore.userData?.user.login
 
     api.type('collections').get(query)
       .then ([favorites]) =>


### PR DESCRIPTION
allow unauthenticated users to see data and classify. 

Steps to reproduce: 
1. remain unauthenticated and goto classify page
2. reload -> get a user null error in console from favs.
