### PR TITLE
Lock markdownz to 2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "classnames": "^2.1.3",
     "counterpart": "~0.16.8",
     "lodash": "^3.10.1",
-    "markdownz": "^2.0.1",
+    "markdownz": "2.4.0",
     "modal-form": "0.0.1",
     "panoptes-client": "~0.1.2",
     "react": "0.13.3",


### PR DESCRIPTION
- Newer versions of markdownz added an image-resizer plugin which does not play nicely with webpack.
- To ensure the site works properly with fresh installs, lock markdownz for now.
