### PR TITLE
sign out from panoptes session

### DIFF
--- a/app/stores/user-store.coffee
+++ b/app/stores/user-store.coffee
@@ -85,6 +85,14 @@ module.exports = Reflux.createStore
   onSignOut: ->
     @_removeToken()
     @getUser()
+    fetch(client.host + '/users/sign_out', {
+      credentials: 'include',
+      method: 'DELETE',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+    })
 
   _tokenExists: ->
     extractToken(window.location.hash) || localStorage.getItem('bearer_token')


### PR DESCRIPTION
use server side cors allow and ensure cookies are sent to leverage devise sign out methods.
