### PR TITLE
Add Beta link for WildCam Gorongosa Labs.

### DIFF
--- a/app/partials/main-header.cjsx
+++ b/app/partials/main-header.cjsx
@@ -15,6 +15,8 @@ counterpart.registerTranslations 'en',
       fieldGuide: 'Field Guide'
       talk: 'Talk'
       blog: 'Blog'
+      lab: 'Lab'
+      beta: 'Beta'
 
 module.exports = React.createClass
   displayName: 'MainHeader'
@@ -62,6 +64,7 @@ module.exports = React.createClass
           <Link to="field-guide" className="main-header-link"><Translate content="mainHeader.links.fieldGuide" /></Link>
           <a className="main-header-link" href="https://www.zooniverse.org/projects/zooniverse/wildcam-gorongosa/talk" target="_blank"><Translate content="mainHeader.links.talk" /></a>
           <a className="main-header-link" href="http://blog.wildcamgorongosa.org" target="_blank"><Translate content="mainHeader.links.blog" /></a>
+          <a className="main-header-link" href="https://learn.wildcamgorongosa.org" target="_blank"><Translate content="mainHeader.links.lab" /><span className="subtext"><Translate content="mainHeader.links.beta" /></span></a>
         </div>
         {if @props.user
           <AccountBar user={@props.user} />

--- a/css/main-header.styl
+++ b/css/main-header.styl
@@ -88,6 +88,7 @@
       min-width: 70px
       outline: none
       padding: 0.5em 1em 0.6em
+      position: relative
       text-align: center
       text-decoration: none
 
@@ -102,6 +103,14 @@
 
       &:last-of-type
         margin-right: 0
+        
+      .subtext
+        color: #c63
+        position: absolute
+        font-size: 0.6em
+        bottom: 0.2em
+        right: 0.4em
+        text-shadow: 1px 1px #ccc, -1px 1px #ccc, 1px -1px #ccc, -1px -1px #ccc
 
       @media screen and (max-width: 768px)
         color: white


### PR DESCRIPTION
As requested by our partners, we're going to add a link to the [WildCam Gorongosa Lab](https://learn.wildcamgorongosa.org/) educator/researcher tools. Since the Lab is still in development, we've added a 'Beta' label to the link for the time being.

<img width="1280" alt="screen shot 2016-04-18 at 13 26 35" src="https://cloud.githubusercontent.com/assets/13952701/14604313/ce4a4c48-056a-11e6-99a3-7534e3310f34.png">

@aliburchard: just wanted to let you know this is the branch that needs to get merged & deployed before the deadline.
