### PR TITLE
Change URL for WildCam Gorongosa Lab

### DIFF
--- a/app/partials/main-header.cjsx
+++ b/app/partials/main-header.cjsx
@@ -64,7 +64,7 @@ module.exports = React.createClass
           <Link to="field-guide" className="main-header-link"><Translate content="mainHeader.links.fieldGuide" /></Link>
           <a className="main-header-link" href="https://www.zooniverse.org/projects/zooniverse/wildcam-gorongosa/talk" target="_blank"><Translate content="mainHeader.links.talk" /></a>
           <a className="main-header-link" href="http://blog.wildcamgorongosa.org" target="_blank"><Translate content="mainHeader.links.blog" /></a>
-          <a className="main-header-link" href="https://learn.wildcamgorongosa.org" target="_blank"><Translate content="mainHeader.links.lab" /><span className="subtext"><Translate content="mainHeader.links.beta" /></span></a>
+          <a className="main-header-link" href="https://lab.wildcamgorongosa.org" target="_blank"><Translate content="mainHeader.links.lab" /><span className="subtext"><Translate content="mainHeader.links.beta" /></span></a>
         </div>
         {if @props.user
           <AccountBar user={@props.user} />


### PR DESCRIPTION
- Goodbye learn.wildcamgorongosa.org
- Hello lab.wildcamgorongosa.org
- This is just the result of a 'rebranding' of the WCG Lab URL; the subdomain name change took effect last week (21/22 Apr 2016) and was discussed on Slack.
- As an aside, I personally like learn.wildcamgorongosa.org; it has a nice verb-iness to it. Ah well!
