### PR TITLE
Update webpack to 1.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "run-sequence": "^1.1.2",
     "stylus": "~0.51.1",
     "through2": "^2.0.0",
-    "webpack": "~1.10.1"
+    "webpack": "~1.13.1"
   },
   "dependencies": {
     "babelify": "^6.1.3",


### PR DESCRIPTION
Suppresses warnings about deprecated //@ sourceURL and //@ sourceMapURL
