### PR TITLE
Fix Panoptes Classification workflow

### DIFF
--- a/app/stores/classification-store.coffee
+++ b/app/stores/classification-store.coffee
@@ -38,7 +38,7 @@ module.exports = Reflux.createStore
 
   finish: ->
     annotations = _.map annotationsStore.data, (annotation) ->
-      task: 'T1'
+      task: workflowStore.data.first_task
       value: [annotation]
 
     upsert =

--- a/app/stores/classification-store.coffee
+++ b/app/stores/classification-store.coffee
@@ -38,8 +38,8 @@ module.exports = Reflux.createStore
 
   finish: ->
     annotations = _.map annotationsStore.data, (annotation) ->
-      task: 'survey'
-      value: annotation
+      task: 'T1'
+      value: [annotation]
 
     upsert =
       annotations: annotations


### PR DESCRIPTION
Fixes #217 

Issue: WCG uses workflow task name "survey" instead of "T1" which is bloody incorrect. Also, the annotations aren't stored in an array. Also bloody incorrect.
Solution: Get the task name dynamically from the workflow to make sure it's always correct. Also, square brackets.

Ready for review, prepping for immediate deployment.
