### PR TITLE
Fix 219 - Re-enable (Reflux-dependent) functionality for IE11/Edge/etc

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-interpolate-component": "~0.7.1",
     "react-router": "0.13.3",
     "react-translate-component": "~0.9.0",
-    "reflux": "~0.2.8",
+    "reflux": "0.2.8",
     "tether": "HubSpot/tether#df8cd44",
     "underscore": "^1.8.3"
   },


### PR DESCRIPTION
Fixes #219 
- Reverted Reflux to 0.2.8, which prevents breaking changes from 0.2.10+
  - See: https://github.com/reflux/refluxjs/blob/master/CHANGELOG.md
- Tested with IE11+Win7, Chrome/Firefox+OSX

In theory the breaking change is that there are no more implicit Promises in IE11... but the Polyfills, they do nothing!
- `Polyfill.io` - failed
- `es6-promise` - failed
- `native-promise-only` - failed

So for now, I've reverted Reflux to 0.2.8 as the safest option. @eatyourgreens @srallen 
