### PR TITLE
Fix for 223 - replaced module?.exports with module.exports

### DIFF
--- a/app/partials/footer-logo.cjsx
+++ b/app/partials/footer-logo.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'FooterLogo'
 
   render: ->


### PR DESCRIPTION
Fixes #223 
Additional Reference: zooniverse/Panoptes-Front-End#2775
- We're replacing `module?.exports` with `module.exports` because the `?.` operator doesn't seem to be doing anything for the app except _kerplunking_ when compiling in a Windows environment.
- Brian also made a goode case in PFE Issue 2775 why `?.` might be detrimental; if a module doesn't exist, the compile will fail silently yet still attempt to chug along.  
