### PR TITLE
Sync classify URL with assignment state

### DIFF
--- a/app/actions/assignment-actions.coffee
+++ b/app/actions/assignment-actions.coffee
@@ -1,0 +1,5 @@
+Reflux = require 'reflux'
+
+module.exports = Reflux.createActions [
+  'setAssignment'
+]

--- a/app/partials/education-bar.cjsx
+++ b/app/partials/education-bar.cjsx
@@ -2,7 +2,7 @@ React = require 'react'
 Reflux = require 'reflux'
 
 assignmentsStore = require '../stores/assignments-store'
-workflowActions = require '../actions/workflow-actions'
+assignmentActions = require '../actions/assignment-actions'
 
 module.exports = React.createClass
   displayName: 'EducationBar'
@@ -10,19 +10,17 @@ module.exports = React.createClass
     Reflux.connect assignmentsStore, 'assignments'
   ]
 
-  changeWorkflow: (event) ->
-    workflowId = event.target.value || null
-    workflowActions.setWorkflow workflowId
+  changeAssignment: (event) ->
+    assignmentActions.setAssignment event.target.value
 
   renderEducationBar: ->
     <div className="education-bar">
       <h4>Wildcam Labs</h4>
       <p>You're working on:</p>
-      <select onChange={ @changeWorkflow }>
-        <option value="">No assignment</option>
-        { @state.assignments.assignments.map (assignment) ->
-          <option key={ assignment.id } value={ assignment.attributes.workflow_id }>
-            { assignment.attributes.name }
+      <select onChange={ @changeAssignment } value={ @state.assignments.activeAssignment.id }>
+        { @state.assignments.assignments.map (assignment) =>
+          <option key={ assignment.id } value={ assignment.id }>
+            { assignment.name }
           </option>
         }
       </select>

--- a/app/partials/main-header.cjsx
+++ b/app/partials/main-header.cjsx
@@ -59,19 +59,36 @@ module.exports = React.createClass
       </div>
       <nav ref="mainHeaderNav" className="main-header-nav">
         <div className="main-header-nav-link-container">
-          <Link to="classify" className="main-header-link"><Translate content="mainHeader.links.classify" /></Link>
-          <Link to="about" className="main-header-link"><Translate content="mainHeader.links.about" /></Link>
-          <Link to="field-guide" className="main-header-link"><Translate content="mainHeader.links.fieldGuide" /></Link>
-          <a className="main-header-link" href="https://www.zooniverse.org/projects/zooniverse/wildcam-gorongosa/talk" target="_blank"><Translate content="mainHeader.links.talk" /></a>
-          <a className="main-header-link" href="http://blog.wildcamgorongosa.org" target="_blank"><Translate content="mainHeader.links.blog" /></a>
-          <a className="main-header-link" href="https://lab.wildcamgorongosa.org" target="_blank"><Translate content="mainHeader.links.lab" /><span className="subtext"><Translate content="mainHeader.links.beta" /></span></a>
+          <Link to="classify" className="main-header-link">
+            <Translate content="mainHeader.links.classify" />
+          </Link>
+          <Link to="about" className="main-header-link">
+            <Translate content="mainHeader.links.about" />
+          </Link>
+          <Link to="field-guide" className="main-header-link">
+            <Translate content="mainHeader.links.fieldGuide" />
+          </Link>
+          <a className="main-header-link" href="https://www.zooniverse.org/projects/zooniverse/wildcam-gorongosa/talk" target="_blank">
+            <Translate content="mainHeader.links.talk" />
+          </a>
+          <a className="main-header-link" href="http://blog.wildcamgorongosa.org" target="_blank">
+            <Translate content="mainHeader.links.blog" />
+          </a>
+          <a className="main-header-link" href="https://lab.wildcamgorongosa.org" target="_blank">
+            <Translate content="mainHeader.links.lab" />
+            <span className="subtext">
+              <Translate content="mainHeader.links.beta" />
+            </span>
+          </a>
         </div>
         {if @props.user
           <AccountBar user={@props.user} />
         else
           <LoginBar project={@props.project} />}
       </nav>
-      <span ref="closeButtonTitle" className="close-button-title"><Translate content="accountMenu.close"/></span>
+      <span ref="closeButtonTitle" className="close-button-title">
+        <Translate content="accountMenu.close"/>
+      </span>
       <button ref="mobileMenuButton" className="mobile-menu-button" type="button" onClick={@toggleMenu}>
         <img ref="mobileButtonIcon" className="menu-icon" src="./assets/mobile-menu.svg" alt="menu" />
       </button>

--- a/app/routes.cjsx
+++ b/app/routes.cjsx
@@ -5,6 +5,7 @@ module.exports =
   <Route name="root" path="/" handler={require './main'} >
     <DefaultRoute handler={require './pages/home'} ignoreScrollBehavior/>
     <Route name="classify" path="classify" handler={require './pages/classify'} ignoreScrollBehavior/>
+    <Route name="classifyAssignment" path="classify/:assignmentId" handler={require './pages/classify'} ignoreScrollBehavior/>
     <Route name="about-page-controller" path="about" handler={require './pages/about'} ignoreScrollBehavior>
       <DefaultRoute name="about" handler={require './pages/about/default'} />
       <Route name="team" path="team" handler={require './pages/about/team'} />

--- a/app/stores/assignments-store.coffee
+++ b/app/stores/assignments-store.coffee
@@ -1,30 +1,46 @@
+_ = require 'lodash'
 Reflux = require 'reflux'
 
 workflowActions = require '../actions/workflow-actions'
 userActions = require '../actions/user-actions'
+assignmentActions = require '../actions/assignment-actions'
 userStore = require './user-store'
 {api} = require '../api/client'
+config = require '../lib/config'
 
 module.exports = Reflux.createStore
-  listenables: userActions
+  listenables: assignmentActions
   data:
-    assignments: []
-    active: false
+    assignments: [
+      id: '0',
+      name: 'No assignment'
+      workflowId: config.workflowId
+    ]
+    activeAssignment: false
+    active: undefined
 
   init: ->
     userStore.listen (userData) =>
-      if userData
+      if userData?
         @_fetchAssignments userData.user
+      else if userData is null
+        newState = _.assign {}, @data, active: false
+        @data = newState
+        @trigger @data
 
   getInitialState: ->
     @data
 
-  onSignOut: ->
-    @data =
-      assignments: []
-      active: false
-    @trigger @data
-    workflowActions.setWorkflow()
+  onSetAssignment: (newAssignmentId = '0') ->
+    if !@data.activeAssignment or !@data.activeAssignment.id isnt newAssignmentId
+      newState = _.assign {}, @data
+      newState.activeAssignment = newState.assignments.find (assignment) =>
+        assignment.id is newAssignmentId
+
+      if newState.activeAssignment
+        console.warn "Setting assignment to #{newAssignmentId}"
+        @data = newState
+        @trigger @data
 
   _fetchAssignments: (user) ->
     fetch 'https://education-api.zooniverse.org/assignments/',
@@ -37,8 +53,16 @@ module.exports = Reflux.createStore
       response.json()
     .then (json) =>
       if json.data.length
-        @data.active = true
-        @data.assignments = json.data
+        newState = _.assign {}, @data
+        newState.active = true
+        newState.assignments = newState.assignments.concat json.data.map (assignment) ->
+          id: assignment.id
+          workflowId: assignment.attributes.workflow_id
+          name: assignment.attributes.name
+        @data = newState
+        @trigger @data
+        console.info 'assignments', @data
     .catch (err) =>
+      @data.active = false
       console.error 'Error fetching assignments', err
 

--- a/app/stores/favorites-store.coffee
+++ b/app/stores/favorites-store.coffee
@@ -26,12 +26,13 @@ module.exports = Reflux.createStore
         @getSubjectInCollection(@favorites)
 
   getSubjectInCollection: (favorites) ->
-    @subjectID = subjectStore.subject.id
-    if favorites?
-      favorites.get('subjects', id: @subjectID)
-        .then ([subject]) =>
-          @favorited = subject?
-          @trigger @favorited
+    if subjectStore.subject
+      @subjectID = subjectStore.subject.id
+      if favorites?
+        favorites.get('subjects', id: @subjectID)
+          .then ([subject]) =>
+            @favorited = subject?
+            @trigger @favorited
 
   createFavorites: ->
     project = projectConfig.projectId

--- a/app/stores/subject-store.coffee
+++ b/app/stores/subject-store.coffee
@@ -47,5 +47,7 @@ module.exports = Reflux.createStore
       @subject.locations[0]['image/jpeg'] = 'https://zooniverse-export.s3.amazonaws.com' + filename
 
   changeWorkflow: ->
+    @subject = null
     @subjects.length = 0
+    @trigger @subject
     @next()

--- a/app/stores/workflow-store.coffee
+++ b/app/stores/workflow-store.coffee
@@ -1,19 +1,23 @@
 Reflux = require 'reflux'
 {api} = require '../api/client'
-config = require '../lib/config'
 workflowActions = require '../actions/workflow-actions'
+assignmentStore = require './assignments-store'
 
 module.exports = Reflux.createStore
   listenables: workflowActions
   data: null
 
   init: ->
-    @onSetWorkflow()
+    assignmentStore.listen (assignmentData) =>
+      if assignmentData.activeAssignment
+        @setWorkflow assignmentData.activeAssignment.workflowId
 
   getInitialState: ->
     @data
 
-  onSetWorkflow: (workflowId = config.workflowId) ->
-    api.type('workflows').get workflowId
-      .then (@data) =>
-        @trigger @data
+  setWorkflow: (newWorkflowId) ->
+    if !@data or @data.id isnt newWorkflowId
+      api.type('workflows').get newWorkflowId
+        .then (@data) =>
+          console.warn "Workflow set to #{newWorkflowId}"
+          @trigger @data

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Wildcam Gorongosa</title>
-    <meta name="description" content="">
+    <meta name="description" content="We need you to be part of our international conservation efforts in Gorongosa National Park by identifying animals in trail camera photos.">
     <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,700" />
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">


### PR DESCRIPTION
Adds support for assignment URLs, and modifies current URL to match assignment id. Assignments which don't exist but match the URL format don't redirect anywhere, but don't break anything either - I'll come back to this one later in #227. Otherwise, in any other instance of weirdness the user should be directed to the default workflow.

zooniverse/wildcam-gorongosa-education#242
