### PR TITLE
Get default workflow if no assignments. Fix field guide lifecycle. Fi…

### DIFF
--- a/app/lib/field-guide-content/buffalo.coffee
+++ b/app/lib/field-guide-content/buffalo.coffee
@@ -60,6 +60,6 @@ module.exports =
   }, {
     title: 'Distribution'
     content: '''
-    <img src="assets/fieldguide-content/mammals/buffalo/buffalo-map.jpg"
+    <img src="assets/fieldguide-content/mammals/buffalo/buffalo-map.jpg" />
     '''
     }]

--- a/app/lib/field-guide-content/ground_hornbill.coffee
+++ b/app/lib/field-guide-content/ground_hornbill.coffee
@@ -56,5 +56,5 @@ module.exports =
     '''
   },{
     title: 'Distribution'
-    content: '<img src="assets/fieldguide-content/mammals/ground_hornbill/hornbill-map.jpg"/>'
+    content: '<img src="assets/fieldguide-content/birds/ground_hornbill/hornbill-map.jpg"/>'
   }]

--- a/app/partials/field-guide-choice.cjsx
+++ b/app/partials/field-guide-choice.cjsx
@@ -2,6 +2,7 @@ React = require 'react'
 Reflux = require 'reflux'
 _ = require 'lodash'
 classNames = require 'classnames'
+LoadingIndicator = require '../components/loading-indicator'
 
 module.exports = React.createClass
   displayName: 'FieldGuideChoice'
@@ -10,73 +11,89 @@ module.exports = React.createClass
   getKeyFromUrlPath: (choice) ->
     choice.replace(/[aeiouy_]/g, '').toUpperCase()
 
-  render: ->
-    unless @props.workflow
-      return <div></div>
+  getInitialState: ->
+    choice: null
+    images: null
 
+  componentDidMount: ->
+    @getChoiceImages(@props.workflow) if @props.workflow?
+
+  componentWillReceiveProps: (nextProps) ->
+    if @props.workflow isnt nextProps.workflow
+      @getChoiceImages(nextProps.workflow)
+  
+  getChoiceImages: (workflow) ->
     try
       localChoice = require "../lib/field-guide-content/#{ @props.params.choice }"
 
     key = @getKeyFromUrlPath @props.params.choice
 
-    task = @props.workflow.tasks[@props.workflow.first_task]
+    task = workflow.tasks[workflow.first_task]
     task.images = _.mapKeys task.images, (value, key) -> key.toLowerCase()
     sourceChoice = task.choices[key]
 
     if localChoice && sourceChoice
       choice = Object.assign {}, sourceChoice, localChoice
+      images = []
+      choice.images.map (image, i) ->
+        images.push "https://thumbnails.zooniverse.org/400x300/#{ task.images[image.toLowerCase()].replace(/.*?:\/\//g, '') }"
+      @setState { choice: choice, images: images }
     else
       return <div></div>
 
-    images = choice.images.map (image, i) ->
-      src = "https://thumbnails.zooniverse.org/400x300/#{ task.images[image.toLowerCase()].replace(/.*?:\/\//g, '') }"
+  render: ->
+    unless @props.workflow
+      return <div></div>
 
-    featuredImage = choice.mainImage || images[0]
+    if @state.choice and @state.images
+      featuredImage = @state.choice?.mainImage || @state.images[0]
 
-    <div className="field-guide-entry">
-      <div className="field-guide-entry-title"><h1>{choice.label}</h1></div>
+      <div className="field-guide-entry">
+        <div className="field-guide-entry-title"><h1>{@state.choice.label}</h1></div>
 
-      {if choice.scientificName
-        <div className="field-guide-entry-scientific-name">{choice.scientificName}</div>}
+        {if @state.choice.scientificName
+          <div className="field-guide-entry-scientific-name">{@state.choice.scientificName}</div>}
 
-      {if choice.conservationStatus
-        <div>Status: {choice.conservationStatus}</div>}
+        {if @state.choice.conservationStatus
+          <div>Status: {@state.choice.conservationStatus}</div>}
 
-      <p className="field-guide-entry-description">{choice.description}</p>
+        <p className="field-guide-entry-description">{@state.choice.description}</p>
 
-      <div className="field-guide-entry-content">
-        <div className="columns">
-          <div className="column">
-            <img src={featuredImage} alt={choice.label} />
+        <div className="field-guide-entry-content">
+          <div className="columns">
+            <div className="column">
+              <img src={featuredImage} alt={@state.choice.label} />
+            </div>
+            <div className="column">
+              <table cellSpacing="0" cellPadding="0">
+                <tr><th colSpan="2">Information</th></tr>
+                {if @state.choice.information
+                  for item, i in @state.choice.information
+                    <tr key={i}>
+                      <td><b>{item.label}</b></td>
+                      <td>{item.value}</td>
+                    </tr>
+                else
+                  <tr><td>No information available</td></tr>}
+              </table>
+            </div>
           </div>
-          <div className="column">
-            <table cellSpacing="0" cellPadding="0">
-              <tr><th colSpan="2">Information</th></tr>
-              {if choice.information
-                for item, i in choice.information
-                  <tr key={i}>
-                    <td><b>{item.label}</b></td>
-                    <td>{item.value}</td>
-                  </tr>
-              else
-                <tr><td>No information available</td></tr>}
-            </table>
-          </div>
+          {if @state.choice.sections
+            <div className="field-guide-entry-sections">
+              {for section, i in @state.choice.sections
+                classes = classNames ['field-guide-entry-section', section.style || false]
+                <div key={i} className={classes}>
+                  <div><b>{section.title}</b></div>
+                  <div className="field-guide-entry-section-content" dangerouslySetInnerHTML={{__html: section.content}}></div>
+                </div>}
+            </div>}
         </div>
-        {if choice.sections
-          <div className="field-guide-entry-sections">
-            {for section, i in choice.sections
-              classes = classNames ['field-guide-entry-section', section.style || false]
-              <div key={i} className={classes}>
-                <div><b>{section.title}</b></div>
-                <div className="field-guide-entry-section-content" dangerouslySetInnerHTML={{__html: section.content}} />
-              </div>}
-          </div>}
-      </div>
 
-      <h3>Trail Camera Images</h3>
-      <div className="field-guide-entry-gallery">
-        {images.map (src, i) ->
-          <div key={i} className="field-guide-entry-gallery-image"><img src={src} alt={choice.label} /></div>}
+        <h3>Trail Camera Images</h3>
+        <div className="field-guide-entry-gallery">
+          {@state.images.map (src, i) =>
+            <div key={i} className="field-guide-entry-gallery-image"><img src={src} alt={@state.choice.label} /></div>}
+        </div>
       </div>
-    </div>
+    else
+      <LoadingIndicator />

--- a/app/stores/workflow-store.coffee
+++ b/app/stores/workflow-store.coffee
@@ -2,6 +2,7 @@ Reflux = require 'reflux'
 {api} = require '../api/client'
 workflowActions = require '../actions/workflow-actions'
 assignmentStore = require './assignments-store'
+projectStore = require './project-store'
 
 module.exports = Reflux.createStore
   listenables: workflowActions
@@ -11,9 +12,14 @@ module.exports = Reflux.createStore
     assignmentStore.listen (assignmentData) =>
       if assignmentData.activeAssignment
         @setWorkflow assignmentData.activeAssignment.workflowId
+      else
+        @listenTo projectStore, @getDefaultWorkflow
 
   getInitialState: ->
     @data
+
+  getDefaultWorkflow: (projectData) ->
+    @setWorkflow projectData.configuration.default_workflow
 
   setWorkflow: (newWorkflowId) ->
     if !@data or @data.id isnt newWorkflowId
@@ -21,3 +27,4 @@ module.exports = Reflux.createStore
         .then (@data) =>
           console.warn "Workflow set to #{newWorkflowId}"
           @trigger @data
+


### PR DESCRIPTION
This fixes the broken field guide if a user navigates directly to a field guide entry. The field guide depends on a workflow to get images and content. The workflow store will now fetch the default workflow if one is not assigned. This should be tested against the the workflow assignments to make sure I didn't break anything with the education stuff. I also reworked the field guide choice component to use lifecycle methods and fix a bit of content. 

As an aside, the warthog is missing an image. We should also consider reworking the content to use markdown instead of dangerously setting inner HTML.
