### PR TITLE
Match assignment url

### DIFF
--- a/app/stores/user-store.coffee
+++ b/app/stores/user-store.coffee
@@ -14,14 +14,12 @@ checkStatus = (response) ->
 parseJson = (response) ->
   response.json()
 
-assignmentPath = ''
-  
 extractToken = (hash) -> 
   if hash.indexOf('assignment') > -1
     match = hash.match(/classify\/assignment-(\d+)\/access_token=([\w\-\.]+)/)
-    console.log 'match: ', match
     if !!match && match[2] 
-      assignmentPath = 'classify/assignment-' + match[1]
+      assignmentPath = '/classify/assignment-' + match[1]
+      window.location.hash = assignmentPath
       match[2]
     else
       null
@@ -88,7 +86,6 @@ module.exports = Reflux.createStore
 
   signInUrl: (location = null) ->
     location ?= window.location
-    location.hash = assignmentPath
     client.host + '/oauth/authorize' +
       "?response_type=token" +
       "&client_id=#{ client.appID }" +

--- a/app/stores/user-store.coffee
+++ b/app/stores/user-store.coffee
@@ -14,12 +14,24 @@ checkStatus = (response) ->
 parseJson = (response) ->
   response.json()
 
-extractToken = (hash) ->
-  match = hash.match(/access_token=([\w\-\.]+)/)
-  if !!match && match[1]
-    match[1]
+assignmentPath = ''
+  
+extractToken = (hash) -> 
+  if hash.indexOf('assignment') > -1
+    match = hash.match(/classify\/assignment-(\d+)\/access_token=([\w\-\.]+)/)
+    console.log 'match: ', match
+    if !!match && match[2] 
+      assignmentPath = 'classify/assignment-' + match[1]
+      match[2]
+    else
+      null
   else
-    null
+    match = hash.match(/access_token=([\w\-\.]+)/) 
+    if !!match && match[1]
+      match[1]
+    else
+      null
+  
 
 module.exports = Reflux.createStore
   listenables: userActions
@@ -76,7 +88,7 @@ module.exports = Reflux.createStore
 
   signInUrl: (location = null) ->
     location ?= window.location
-
+    location.hash = assignmentPath
     client.host + '/oauth/authorize' +
       "?response_type=token" +
       "&client_id=#{ client.appID }" +


### PR DESCRIPTION
This adds support for accepting login requests from Wildcam Lab urls of this form `https:/#/classify/assignment-30/access_token=eyJ0e`. It is a step towards fixing this https://github.com/zooniverse/wildcam-gorongosa-education/issues/271

Use case: when a _logged-in_ Wildcam Lab student clicks on "start assignment", they should be redirected to the classifying interface and the correct assignment - without having to login again.

The code: now `extractToken` first matches url hashes that contain assignment paths; then it sets the location to pass to `signInUrl` to the assignment path and extract the token.
