### PR TITLE
Track progress of Assignment

### DIFF
--- a/app/actions/assignment-actions.coffee
+++ b/app/actions/assignment-actions.coffee
@@ -1,5 +1,6 @@
 Reflux = require 'reflux'
 
 module.exports = Reflux.createActions [
-  'setAssignment'
+  'setAssignment',
+  'incrementClassificationProgress'
 ]

--- a/app/partials/education-bar.cjsx
+++ b/app/partials/education-bar.cjsx
@@ -24,6 +24,7 @@ module.exports = React.createClass
           </option>
         }
       </select>
+      {@renderMyClassificationsCount()}
     </div>
 
   render: ->
@@ -31,3 +32,21 @@ module.exports = React.createClass
       @renderEducationBar()
     else
       null
+
+  renderMyClassificationsCount: ->
+    htmlCounter = null
+    if @state.assignments.activeAssignment && @state.assignments.activeAssignment.id != '0'
+      classificationTarget = parseInt(@state.assignments.activeAssignment.classificationTarget)
+      if isNaN(classificationTarget)
+        classificationTarget = ''
+      else
+        classificationTarget = ' / ' + classificationTarget
+      myClassificationCount = @state.assignments.activeAssignment.myClassificationCount
+      
+      htmlCounter =
+        <div className="my-classifications">
+          <label>My Classifications:</label>
+          <span>{myClassificationCount}{classificationTarget}</span>
+        </div>
+    
+    return htmlCounter

--- a/app/partials/education-bar.cjsx
+++ b/app/partials/education-bar.cjsx
@@ -45,7 +45,7 @@ module.exports = React.createClass
       
       htmlCounter =
         <div className="my-classifications">
-          <label>My Classifications:</label>
+          <label>Progress:</label>
           <span>{myClassificationCount}{classificationTarget}</span>
         </div>
     

--- a/app/stores/assignments-store.coffee
+++ b/app/stores/assignments-store.coffee
@@ -43,6 +43,11 @@ module.exports = Reflux.createStore
         console.warn "Setting assignment to #{newAssignmentId}"
         @data = newState
         @trigger @data
+        
+  onIncrementClassificationProgress: () ->
+    newState = _.assign {}, @data
+    if newState.activeAssignment
+      newState.activeAssignment.myClassificationCount++
 
   _fetchAssignments: (user) ->
     fetch 'https://education-api.zooniverse.org/assignments/',
@@ -58,19 +63,12 @@ module.exports = Reflux.createStore
         newState = _.assign {}, @data
         newState.active = true
         
-        console.log('-'.repeat(80))
-        console.log(json)
-        
-        x = json.included.find (student) ->
-          student.attributes.student_user_id == 716 && student.id == '34'
-        console.log x
-        
         newState.assignments = newState.assignments.concat json.data.map (assignment) ->
           id: assignment.id
           workflowId: assignment.attributes.workflow_id
           name: assignment.attributes.name
           classificationTarget: assignment.attributes.metadata.classifications_target ? ''
-          myClassificationCount: 999
+          myClassificationCount: 999999 #TODO: determine my initial Classification Count
           
         @data = newState
         @trigger @data

--- a/app/stores/assignments-store.coffee
+++ b/app/stores/assignments-store.coffee
@@ -15,6 +15,8 @@ module.exports = Reflux.createStore
       id: '0',
       name: 'No assignment'
       workflowId: config.workflowId
+      classificationTarget: ''
+      myClassificationCount: 0
     ]
     activeAssignment: false
     active: undefined
@@ -55,10 +57,21 @@ module.exports = Reflux.createStore
       if json.data.length
         newState = _.assign {}, @data
         newState.active = true
+        
+        console.log('-'.repeat(80))
+        console.log(json)
+        
+        x = json.included.find (student) ->
+          student.attributes.student_user_id == 716 && student.id == '34'
+        console.log x
+        
         newState.assignments = newState.assignments.concat json.data.map (assignment) ->
           id: assignment.id
           workflowId: assignment.attributes.workflow_id
           name: assignment.attributes.name
+          classificationTarget: assignment.attributes.metadata.classifications_target ? ''
+          myClassificationCount: 999
+          
         @data = newState
         @trigger @data
         console.info 'assignments', @data

--- a/app/stores/classification-store.coffee
+++ b/app/stores/classification-store.coffee
@@ -6,9 +6,10 @@ config = require '../lib/config'
 classifierActions = require '../actions/classifier-actions'
 
 annotationsStore = require './annotations-store'
-projectStore = require './project-store'
+#projectStore = require './project-store'
 subjectStore = require './subject-store'
 workflowStore = require './workflow-store'
+assignmentActions = require '../actions/assignment-actions'
 
 module.exports = Reflux.createStore
   data: null
@@ -37,6 +38,7 @@ module.exports = Reflux.createStore
     @trigger @data
 
   finish: ->
+    assignmentActions.incrementClassificationProgress()    
     annotations = _.map annotationsStore.data, (annotation) ->
       task: workflowStore.data.first_task
       value: [annotation]

--- a/css/education-bar.styl
+++ b/css/education-bar.styl
@@ -4,11 +4,12 @@
   color: white
   padding: 1em 1vw
   display: flex
+  flex-wrap: wrap
   align-items: center
   margin-bottom: 10px
 
   select
-    font-size: 2em
+    font-size: 1em
     display: block
 
   h4
@@ -18,3 +19,10 @@
   p
     margin: 0
     margin-right: 0.5em
+  
+  .my-classifications
+    margin-left: 2em
+    
+    label
+      margin-right: 0.5em
+      font-weight: bold


### PR DESCRIPTION
Features
- When a logged-in user has an active Assignment, the number of classifications she/he has made, and the number required by the Assignment (if any), are displayed.
- When a logged-in user with an active Assignment makes a Classification, the Assignment store is updated to account for the progress.
- If there is no active Assignment (i.e. default workflow) there will be no progress counter.

**Features TODO:**
- Currently, I am **unable** to figure out what's the number for "my classifications" for each Assignment when I start the app. (i.e. I don't know how to ask the EduAPI **how many Classifications I've already done.** )
  - This is due to some confusion with the JSON data, and needs discussion.
  - For the moment, I've made the number for "my classifications" to default to an obviously incorrect 999999 at app start.
  - You can still see the numbers increase correctly as you make Classifications, though.

Features to Discuss:
- In reference to #237 - How should we inform users that they've already completed the required number of Classifications for their Assignment? An alert() box would be too obnoxious.

For reference, the code to change would be in `app/stores/assignments-store.coffee`, function `onIncrementClassificationProgress()`, e.g.: 

```
onIncrementClassificationProgress: () ->
  newState = _.assign {}, @data
  if newState.activeAssignment
    newState.activeAssignment.myClassificationCount++

    targetCount = parseInt(newState.activeAssignment.classificationTarget)
    if !isNaN(targetCount) && targetCount <= newState.activeAssignment.myClassificationCount
      alert('Good job! You've finished your assignment, maybe do something else now?')
```

Supercedes #241, fixes #240

@simoneduca , let's talk about this tomorrow.
