### PR TITLE
do not get a favs collection for a non-logged in user

### DIFF
--- a/app/stores/favorites-store.coffee
+++ b/app/stores/favorites-store.coffee
@@ -15,15 +15,18 @@ module.exports = Reflux.createStore
     @favorited
 
   getFavorites: ->
-    query =
-      project_id: projectConfig.projectId
-      favorite: true
-      owner: userStore.userData?.user.login
+    if not userStore.userData?
+      @favorites = null
+    else
+      query =
+        project_id: projectConfig.projectId
+        favorite: true
+        owner: userStore.userData.user.login
 
-    api.type('collections').get(query)
-      .then ([favorites]) =>
-        @favorites = if favorites? then favorites else null
-        @getSubjectInCollection(@favorites)
+      api.type('collections').get(query)
+        .then ([favorites]) =>
+          @favorites = if favorites? then favorites else null
+          @getSubjectInCollection(@favorites)
 
   getSubjectInCollection: (favorites) ->
     if subjectStore.subject


### PR DESCRIPTION
we don't get the favourites collection unless the user is logged in, this will avoid some extraneous collection calls on the api that aren't used
