### PR TITLE
Add Finished/Retired banner

### DIFF
--- a/app/pages/classify.cjsx
+++ b/app/pages/classify.cjsx
@@ -135,6 +135,11 @@ module.exports = React.createClass
                 <img src={@state.subject.locations[0]['image/jpeg']} />
                 <span className="already-seen-notice">Already seen</span>
               </div>
+            else if @state.subject.retired
+              <div className="subject-image-container">
+                <img src={@state.subject.locations[0]['image/jpeg']} />
+                <span className="already-seen-notice">Finished</span>
+              </div>
             else
               <img src={@state.subject.locations[0]['image/jpeg']} />
           else


### PR DESCRIPTION
## PR Review
This PR adds a "Finished" banner for Subjects that are already retired.

![screen shot 2017-11-29 at 17 25 38](https://user-images.githubusercontent.com/13952701/33389690-99dee08a-d52b-11e7-8a24-ee68c3d69457.png)

The precedence is: if Already Seen, show that banner. If Retired, show that banner. Otherwise, show the regular ol' Subject photo on its own.

### Status
I'm taking responsibility for merging & deploying this.