### PR TITLE
Fix: accept 'image/png' images

### DIFF
--- a/app/stores/subject-store.coffee
+++ b/app/stores/subject-store.coffee
@@ -31,6 +31,11 @@ module.exports = Reflux.createStore
 
   loadSubjectImage: ->
     @subject = @subjects.shift()
+    
+    #Fix: some image locations are erroneously tagged as images/png; this workaround ensures standardisation. (-shaun 20171205)
+    if @subject.locations[0]['image/png']? and not @subject.locations[0]['image/jpeg']?
+      @subject.locations[0]['image/jpeg'] = @subject.locations[0]['image/png']
+    
     @generateHttpsUrl()
     image = new Image()
     image.src = @subject.locations[0]['image/jpeg']


### PR DESCRIPTION
## PR Overview
This PRs allows the website to accept Subject images when they're marked as `image/png`, in addition to the expected `image/jpeg`.

Context: A recent upload of new WildCam Gorongosa Subjects has erroneously marked JPG images with the `image/png` metadata. The WildCam Gorongosa website implicitly expects `image/jpeg`, so a workaround is needed to accept these new Subjects.

### Status
Some final bits of testing needed, then I'll take responsibility to merge & deploy.