### PR TITLE
Increase subjects per queue

### DIFF
--- a/app/stores/subject-store.coffee
+++ b/app/stores/subject-store.coffee
@@ -27,7 +27,8 @@ module.exports = Reflux.createStore
         #default 10 subjects when the workflow is fully classified/retired. By
         #increasing the number of subjects to 100 (order is randomised), we
         #mask the repetition of subjects for classroom users.
-        #This workaround is requested by HHMI themselves. (@shaun 20180214)
+        #This workaround is requested by HHMI themselves.
+        #(@shaun 20180214)
 
       api.get('/subjects/queued', query)
         .then (subjects) =>


### PR DESCRIPTION
## PR Overview
Increases subjects in queue, so users will have a larger variety of photos when workflow is fully classified/retired.

Context: in Feb 2018, HHMI-aligned teachers attempted to use WildCam Gorongosa for their classrooms but found that the app kept serving the same 10 images; this is the result of Panoptes (by design) serving the default 10 subjects when the workflow is fully classified/retired. By
#increasing the number of subjects to 100 (order is randomised), we mask the repetition of subjects for classroom users. This workaround is requested by HHMI themselves.

### Dev Notes
Apologies, as I seriously DERPED on this one. Instead of creating a branch, I accidentally made the commit on `master` and pushed it. This PR exists only used to record what I actually did.

Actual commit: https://github.com/zooniverse/wildcam-gorongosa/commit/ff9e18ffdb48935ce176294f85ad22f282aada67

Added code, in `app/stores/subject-store.coffee`
```
     if @subjects.length == 0
       query =
         workflow_id: workflowStore.data.id
+        page_size: 100  #Increases subjects in queue, so users will have a larger variety of photos when workflow is fully classified/retired.
+
+        #Context: in Feb 2018, HHMI-aligned teachers attempted to use WildCam
+        #Gorongosa for their classrooms but found that the app kept serving the
+        #same 10 images; this is the result of Panoptes (by design) serving the
+        #default 10 subjects when the workflow is fully classified/retired. By
+        #increasing the number of subjects to 100 (order is randomised), we
+        #mask the repetition of subjects for classroom users.
+        #This workaround is requested by HHMI themselves. (@shaun 20180214)
```

### Status
Apologetically merging.