### PR TITLE
[FUTURE REVERSION] Revert size of subject queue to default

### DIFF
--- a/app/stores/subject-store.coffee
+++ b/app/stores/subject-store.coffee
@@ -19,16 +19,8 @@ module.exports = Reflux.createStore
     if @subjects.length == 0
       query =
         workflow_id: workflowStore.data.id
-        page_size: 100  #Increases subjects in queue, so users will have a larger variety of photos when workflow is fully classified/retired.
-
-        #Context: in Feb 2018, HHMI-aligned teachers attempted to use WildCam
-        #Gorongosa for their classrooms but found that the app kept serving the
-        #same 10 images; this is the result of Panoptes (by design) serving the
-        #default 10 subjects when the workflow is fully classified/retired. By
-        #increasing the number of subjects to 100 (order is randomised), we
-        #mask the repetition of subjects for classroom users.
-        #This workaround is requested by HHMI themselves.
-        #(@shaun 20180214)
+        page_size: 10  #Panotes's /subjects/queued will return same default subjects when workflow is 100% classified/retired.
+        #10 is default, increase to 100 if users (e.g. HHMI teachers) request to see more varied subjects for demonstrating to classrooms.
 
       api.get('/subjects/queued', query)
         .then (subjects) =>


### PR DESCRIPTION
## PR Review
This PR reverts a temporary workaround introduced in PR #251 (well, commit https://github.com/zooniverse/wildcam-gorongosa/commit/ff9e18ffdb48935ce176294f85ad22f282aada67) that increases the number of subjects returned by Panoptes's `/subjects/queued` endpoint

The workaround was in place because teachers using wildcamgorongosa.org as a classroom tool noticed repeating images, which happens when the workflow is fully classified/retired.

### Status
This PR is intended for executing a reversion at a future date.

DO NOT MERGE until either:
1. WildCam Gorongosa gets new Subjects, putting it out of 'finished/retired' mode, or
2. someone can check with HHMI that teachers are no longer using wildcamgorongosa.org as a classroom (e.g. they have all fully embraced WildCam Lab)